### PR TITLE
Initialize LOD to be coherent to default zoom value

### DIFF
--- a/lib/src/core/controllers/node_editor/core.dart
+++ b/lib/src/core/controllers/node_editor/core.dart
@@ -171,13 +171,13 @@ class FlNodeEditorController {
   /// Rendering accellerators are data stored in the controller to speed up rendering.
   ////////////////////////////////////////////////////////////////////////////////
 
-  int lodLevel = 0;
+  late int lodLevel = _computeLODLevel(viewportZoom);
   bool nodesDataDirty = false;
   bool linksDataDirty = false;
 
   /// This method is used to compute the level of detail (LOD) based on the zoom level and
   /// it's called automatically by the controller when the zoom level is changed.
-  int _computeLODLevel(double zoom) {
+  static int _computeLODLevel(double zoom) {
     if (zoom > 0.5) {
       return 4;
     } else if (zoom > 0.25) {


### PR DESCRIPTION
Since the default zoom value for the controller is `1`, the default LOD should be `4`; however, it was initialized to 0 by default. This caused some elements (e.g. ports, grid) to not render properly when creating a new controller. This PR fixes this by simply computing the initial LOD value based on the initial zoom value.

(This bug was not noticeable with the example project since it loads an existing project at startup, which updates the zoom and offset, causing the LOD to be properly computed.)