### PR TITLE
[BREAKING] Make port compatibility aware of type inheritance when checking each port's data type

### DIFF
--- a/example/lib/nodes.dart
+++ b/example/lib/nodes.dart
@@ -93,10 +93,9 @@ NodePrototype createValueNode<T>({
         displayName: 'Completed',
         styleBuilder: controlOutputPortStyle,
       ),
-      DataOutputPortPrototype(
+      DataOutputPortPrototype<T>(
         idName: 'value',
         displayName: 'Value',
-        dataType: T,
         styleBuilder: outputDataPortStyle,
       ),
     ],
@@ -331,16 +330,14 @@ void registerNodes(BuildContext context, FlNodeEditorController controller) {
           displayName: 'Exec',
           styleBuilder: controlInputPortStyle,
         ),
-        DataInputPortPrototype(
+        DataInputPortPrototype<double>(
           idName: 'a',
           displayName: 'A',
-          dataType: double,
           styleBuilder: inputDataPortStyle,
         ),
-        DataInputPortPrototype(
+        DataInputPortPrototype<double>(
           idName: 'b',
           displayName: 'B',
-          dataType: double,
           styleBuilder: inputDataPortStyle,
         ),
         ControlOutputPortPrototype(
@@ -348,10 +345,9 @@ void registerNodes(BuildContext context, FlNodeEditorController controller) {
           displayName: 'Completed',
           styleBuilder: controlOutputPortStyle,
         ),
-        DataOutputPortPrototype(
+        DataOutputPortPrototype<double>(
           idName: 'result',
           displayName: 'Result',
-          dataType: double,
           styleBuilder: outputDataPortStyle,
         ),
       ],
@@ -428,10 +424,9 @@ void registerNodes(BuildContext context, FlNodeEditorController controller) {
           displayName: 'Completed',
           styleBuilder: controlOutputPortStyle,
         ),
-        DataOutputPortPrototype(
+        DataOutputPortPrototype<double>(
           idName: 'value',
           displayName: 'Value',
-          dataType: double,
           styleBuilder: outputDataPortStyle,
         ),
       ],
@@ -468,10 +463,9 @@ void registerNodes(BuildContext context, FlNodeEditorController controller) {
           displayName: 'Exec',
           styleBuilder: controlInputPortStyle,
         ),
-        DataInputPortPrototype(
+        DataInputPortPrototype<bool>(
           idName: 'condition',
           displayName: 'Condition',
-          dataType: bool,
           styleBuilder: inputDataPortStyle,
         ),
         ControlOutputPortPrototype(
@@ -523,13 +517,11 @@ void registerNodes(BuildContext context, FlNodeEditorController controller) {
         DataInputPortPrototype(
           idName: 'a',
           displayName: 'A',
-          dataType: dynamic,
           styleBuilder: inputDataPortStyle,
         ),
         DataInputPortPrototype(
           idName: 'b',
           displayName: 'B',
-          dataType: dynamic,
           styleBuilder: inputDataPortStyle,
         ),
         ControlOutputPortPrototype(
@@ -537,10 +529,9 @@ void registerNodes(BuildContext context, FlNodeEditorController controller) {
           displayName: 'Completed',
           styleBuilder: controlOutputPortStyle,
         ),
-        DataOutputPortPrototype(
+        DataOutputPortPrototype<bool>(
           idName: 'result',
           displayName: 'Result',
-          dataType: bool,
           styleBuilder: outputDataPortStyle,
         ),
       ],
@@ -626,7 +617,6 @@ void registerNodes(BuildContext context, FlNodeEditorController controller) {
         DataInputPortPrototype(
           idName: 'value',
           displayName: 'Value',
-          dataType: dynamic,
           styleBuilder: inputDataPortStyle,
         ),
         ControlOutputPortPrototype(
@@ -676,10 +666,9 @@ void registerNodes(BuildContext context, FlNodeEditorController controller) {
           displayName: 'Exec',
           styleBuilder: controlInputPortStyle,
         ),
-        DataInputPortPrototype(
+        DataInputPortPrototype<double>(
           idName: 'value',
           displayName: 'Value',
-          dataType: double,
           styleBuilder: inputDataPortStyle,
         ),
         ControlOutputPortPrototype(
@@ -687,10 +676,9 @@ void registerNodes(BuildContext context, FlNodeEditorController controller) {
           displayName: 'Completed',
           styleBuilder: controlOutputPortStyle,
         ),
-        DataOutputPortPrototype(
+        DataOutputPortPrototype<int>(
           idName: 'rounded',
           displayName: 'Rounded',
-          dataType: int,
           styleBuilder: outputDataPortStyle,
         ),
       ],
@@ -766,7 +754,6 @@ void registerNodes(BuildContext context, FlNodeEditorController controller) {
         DataInputPortPrototype(
           idName: 'list',
           displayName: 'List',
-          dataType: dynamic,
           styleBuilder: inputDataPortStyle,
         ),
         ControlOutputPortPrototype(
@@ -782,13 +769,11 @@ void registerNodes(BuildContext context, FlNodeEditorController controller) {
         DataOutputPortPrototype(
           idName: 'listElem',
           displayName: 'List Element',
-          dataType: dynamic,
           styleBuilder: outputDataPortStyle,
         ),
-        DataOutputPortPrototype(
+        DataOutputPortPrototype<int>(
           idName: 'listIdx',
           displayName: 'List Index',
-          dataType: int,
           styleBuilder: outputDataPortStyle,
         ),
       ],

--- a/lib/src/core/models/entities.dart
+++ b/lib/src/core/models/entities.dart
@@ -125,6 +125,11 @@ abstract class PortPrototype {
     required this.direction,
     required this.type,
   });
+
+  bool compatibleWith(PortPrototype other) =>
+      direction != other.direction &&
+      type == other.type &&
+      dataType == other.dataType;
 }
 
 class DataInputPortPrototype extends PortPrototype {

--- a/lib/src/core/models/entities.dart
+++ b/lib/src/core/models/entities.dart
@@ -126,28 +126,45 @@ abstract class PortPrototype {
     required this.type,
   });
 
-  bool compatibleWith(PortPrototype other) =>
-      direction != other.direction &&
-      type == other.type &&
-      dataType == other.dataType;
+  bool compatibleWith(PortPrototype other);
 }
 
-class DataInputPortPrototype extends PortPrototype {
+class DataInputPortPrototype<T> extends PortPrototype {
   DataInputPortPrototype({
     required super.idName,
     required super.displayName,
     super.styleBuilder,
-    super.dataType,
-  }) : super(direction: PortDirection.input, type: PortType.data);
+  }) : super(dataType: T, direction: PortDirection.input, type: PortType.data);
+
+  // called by [DataOutputPortPrototype.compatibleWith], see note there
+  bool _isCompatibleWithOutput(PortPrototype other) =>
+      other is DataOutputPortPrototype<T>;
+
+  @override
+  bool compatibleWith(PortPrototype other) => _isCompatibleWithOutput(other);
 }
 
-class DataOutputPortPrototype extends PortPrototype {
+class DataOutputPortPrototype<T> extends PortPrototype {
   DataOutputPortPrototype({
     required super.idName,
     required super.displayName,
     super.styleBuilder,
-    super.dataType,
-  }) : super(direction: PortDirection.output, type: PortType.data);
+  }) : super(dataType: T, direction: PortDirection.output, type: PortType.data);
+
+  // the check we'd like to make here is:
+  //    other is DataInputPortPrototype<U> && T is U
+  //      => if [other] is an Input<Animal>, then we should be an Output<Animal/Cat/Dog/...>
+  // which could also be written:
+  //    DataInputPortPrototype<T> is other.runtimeType
+  //    => Input<Cat> is Input<Animal>
+  //
+  // unfortunately dart's type/reflection system is extremely limited,
+  // so you can't easily do that sort of check; instead, we (ab)use the
+  // fact that /instances/ know the actual type parameter, so we ask it
+  // to perform the type check for us
+  @override
+  bool compatibleWith(PortPrototype other) =>
+      other is DataInputPortPrototype && other._isCompatibleWithOutput(this);
 }
 
 class ControlInputPortPrototype extends PortPrototype {
@@ -156,6 +173,10 @@ class ControlInputPortPrototype extends PortPrototype {
     required super.displayName,
     super.styleBuilder,
   }) : super(direction: PortDirection.input, type: PortType.control);
+
+  @override
+  bool compatibleWith(PortPrototype other) =>
+      other is ControlOutputPortPrototype;
 }
 
 class ControlOutputPortPrototype extends PortPrototype {
@@ -164,6 +185,10 @@ class ControlOutputPortPrototype extends PortPrototype {
     required super.displayName,
     super.styleBuilder,
   }) : super(direction: PortDirection.output, type: PortType.control);
+
+  @override
+  bool compatibleWith(PortPrototype other) =>
+      other is ControlInputPortPrototype;
 }
 
 /// The state of a port painted on the canvas.

--- a/lib/src/widgets/deafult_node_widget.dart
+++ b/lib/src/widgets/deafult_node_widget.dart
@@ -638,12 +638,7 @@ class _DefaultNodeWidgetState extends State<DefaultNodeWidget> {
           widget.controller.nodes[_tempLink!.nodeId]!.ports[_tempLink!.portId]!;
       widget.controller.nodePrototypes.forEach((key, value) {
         if (value.ports.any(
-          (port) =>
-              port.direction != startPort.prototype.direction &&
-              port.type == startPort.prototype.type &&
-              (port.dataType == startPort.prototype.dataType ||
-                  port.dataType == dynamic ||
-                  startPort.prototype.dataType == dynamic),
+          startPort.prototype.compatibleWith,
         )) {
           compatiblePrototypes.add(MapEntry(key, value));
         }
@@ -673,19 +668,11 @@ class _DefaultNodeWidgetState extends State<DefaultNodeWidget> {
               _tempLink!.nodeId,
               _tempLink!.portId,
               addedNode.id,
-              addedNode.ports.entries
+              addedNode.ports.values
+                  .map((port) => port.prototype)
                   .firstWhere(
-                    (port) =>
-                        port.value.prototype.direction !=
-                            startPort.prototype.direction &&
-                        port.value.prototype.type == startPort.prototype.type &&
-                        (port.value.prototype.dataType ==
-                                startPort.prototype.dataType ||
-                            port.value.prototype.dataType == dynamic ||
-                            startPort.prototype.dataType == dynamic),
+                    startPort.prototype.compatibleWith,
                   )
-                  .value
-                  .prototype
                   .idName,
             );
             _isLinking = false;

--- a/lib/src/widgets/node_editor_data_layer.dart
+++ b/lib/src/widgets/node_editor_data_layer.dart
@@ -521,12 +521,7 @@ class _NodeEditorDataLayerState extends State<NodeEditorDataLayer>
         widget.controller.nodePrototypes.forEach(
           (key, value) {
             if (value.ports.any(
-              (port) =>
-                  port.direction != startPort.prototype.direction &&
-                  port.type == startPort.prototype.type &&
-                  (port.dataType == startPort.prototype.dataType ||
-                      port.dataType == dynamic ||
-                      startPort.prototype.dataType == dynamic),
+              startPort.prototype.compatibleWith,
             )) {
               compatiblePrototypes.add(MapEntry(key, value));
             }
@@ -564,20 +559,11 @@ class _NodeEditorDataLayerState extends State<NodeEditorDataLayer>
                 _tempLink!.nodeId,
                 _tempLink!.portId,
                 addedNode.id,
-                addedNode.ports.entries
+                addedNode.ports.values
+                    .map((port) => port.prototype)
                     .firstWhere(
-                      (port) =>
-                          port.value.prototype.direction !=
-                              startPort.prototype.direction &&
-                          port.value.prototype.type ==
-                              startPort.prototype.type &&
-                          (port.value.prototype.dataType ==
-                                  startPort.prototype.dataType ||
-                              port.value.prototype.dataType == dynamic ||
-                              startPort.prototype.dataType == dynamic),
+                      startPort.prototype.compatibleWith,
                     )
-                    .value
-                    .prototype
                     .idName,
               );
 


### PR DESCRIPTION
## Context

When two ports are connected together, the editor verifies the type of data they accept to make sure they're actually compatible: you shouldn't connect a port that outputs a number into a port that expects a list.

However, up to now, this only checked for ***strict*** equality between the two ports' types, ignoring covariance or inheritance, meaning that it would be impossible to feed, for example, a `List<string>` into a port that expects a generic `List<dynamic>`.

This is because Dart's reflection/meta-programming capabilities ~suck~ are severely limited, making runtime types completely opaque and stripping away any information about inheritance, type arguments, kind, etc. Thus, it is impossible to establish any relationship between two *runtime* type objects.

## Solution

Thankfully, we can bypass that restriction using compile-time generics and the `is` operator: by making the `DataOutput/DataInputPortPrototype` types generic, they can themselves check that their a certain object is of a *compatible* type (including inheritance, covariance/contravariance, dynamic-ness, unions, etc.). This is achieved in [the 2nd commit](https://github.com/WilliamKarolDiCioccio/fl_nodes/commit/9118e9ed14ba60d41f2eb0160f8075bce0a6d218). It does require [a small hack](https://github.com/WilliamKarolDiCioccio/fl_nodes/blob/9118e9ed14ba60d41f2eb0160f8075bce0a6d218/lib/src/core/models/entities.dart#L154-L168) where the `DataOutput` prototype needs to call a private instance method on `DataInput` (cf linked code) which increases the coupling between them, but... yeah dart's type system sucks

Another prerequisite/side-effect of this was the need to move the port-compatibility check into the prototype class (done in [the 1st commit](https://github.com/WilliamKarolDiCioccio/fl_nodes/commit/22f017fd0ba7c715f2cb7ec33fd7b81347f1c0c3)), which coincidentally increases the extensibility of the library slightly, since the port prototype classes are all inheritable! :D

## Breaking change :warning: 

This, of course, comes with a big breaking change: **`DataInputPortPrototype` and `DataOutputPortPrototype` now accept a single type parameter, which replaces the previous `dataType` parameter**. In cases where the `dataType` parameter wasn't specified before, the type argument can just be omitted and it'll default to dynamic (i.e. the port will accept any type), just like before.