### PR TITLE
Fix uses of `FromTo`'s fields to be less misleading

### DIFF
--- a/lib/src/core/controller/clipboard.dart
+++ b/lib/src/core/controller/clipboard.dart
@@ -48,7 +48,7 @@ class FlNodeEditorClipboard {
       final updatedPorts = nodeCopy.ports.map((portId, port) {
         final deepCopiedLinks = port.links.where((link) {
           return selectedNodeIds.contains(link.fromTo.from) &&
-              selectedNodeIds.contains(link.fromTo.fromPort);
+              selectedNodeIds.contains(link.fromTo.to);
         }).toSet();
 
         return MapEntry(
@@ -179,8 +179,8 @@ class FlNodeEditorClipboard {
                   id: newIds[link.id],
                   fromTo: (
                     from: newIds[link.fromTo.from]!,
-                    to: link.fromTo.to,
-                    fromPort: newIds[link.fromTo.fromPort]!,
+                    fromPort: link.fromTo.fromPort,
+                    to: newIds[link.fromTo.to]!,
                     toPort: link.fromTo.toPort,
                   ),
                 );

--- a/lib/src/core/controller/core.dart
+++ b/lib/src/core/controller/core.dart
@@ -451,11 +451,13 @@ class FlNodeEditorController {
     // if this exact link already exists, don't do anything
     if (port1.links.any(
           (link) =>
-              link.fromTo.from == node2Id && link.fromTo.to == port2IdName,
+              link.fromTo.from == node2Id &&
+              link.fromTo.fromPort == port2IdName,
         ) ||
         port2.links.any(
           (link) =>
-              link.fromTo.from == node1Id && link.fromTo.to == port1IdName,
+              link.fromTo.from == node1Id &&
+              link.fromTo.fromPort == port1IdName,
         )) {
       return null;
     }
@@ -466,16 +468,16 @@ class FlNodeEditorController {
     if (port1.prototype.direction == PortDirection.output) {
       fromTo = (
         from: node1Id,
-        to: port1IdName,
-        fromPort: node2Id,
-        toPort: port2IdName
+        fromPort: port1IdName,
+        to: node2Id,
+        toPort: port2IdName,
       );
     } else {
       fromTo = (
         from: node2Id,
-        to: port2IdName,
-        fromPort: node1Id,
-        toPort: port1IdName
+        fromPort: port2IdName,
+        to: node1Id,
+        toPort: port1IdName,
       );
     }
 
@@ -514,20 +516,20 @@ class FlNodeEditorController {
     bool isHandled = false,
   }) {
     if (!nodes.containsKey(link.fromTo.from) ||
-        !nodes.containsKey(link.fromTo.fromPort)) {
+        !nodes.containsKey(link.fromTo.to)) {
       return;
     }
 
     final fromNode = nodes[link.fromTo.from]!;
-    final toNode = nodes[link.fromTo.fromPort]!;
+    final toNode = nodes[link.fromTo.to]!;
 
-    if (!fromNode.ports.containsKey(link.fromTo.to) ||
+    if (!fromNode.ports.containsKey(link.fromTo.fromPort) ||
         !toNode.ports.containsKey(link.fromTo.toPort)) {
       return;
     }
 
-    final fromPort = nodes[link.fromTo.from]!.ports[link.fromTo.to]!;
-    final toPort = nodes[link.fromTo.fromPort]!.ports[link.fromTo.toPort]!;
+    final fromPort = nodes[link.fromTo.from]!.ports[link.fromTo.fromPort]!;
+    final toPort = nodes[link.fromTo.to]!.ports[link.fromTo.toPort]!;
 
     fromPort.links.add(link);
     toPort.links.add(link);
@@ -566,8 +568,8 @@ class FlNodeEditorController {
     final link = linksById[id]!;
 
     // Remove the link from its associated ports
-    final fromPort = nodes[link.fromTo.from]?.ports[link.fromTo.to];
-    final toPort = nodes[link.fromTo.fromPort]?.ports[link.fromTo.toPort];
+    final fromPort = nodes[link.fromTo.from]?.ports[link.fromTo.fromPort];
+    final toPort = nodes[link.fromTo.to]?.ports[link.fromTo.toPort];
 
     fromPort?.links.remove(link);
     toPort?.links.remove(link);

--- a/lib/src/core/controller/runner.dart
+++ b/lib/src/core/controller/runner.dart
@@ -131,7 +131,7 @@ class FlNodeEditorRunner {
       final connectedNode = _nodes[
           port.prototype.direction == PortDirection.input
               ? link.fromTo.from
-              : link.fromTo.fromPort]!;
+              : link.fromTo.to]!;
       connectedNodeIds.add(connectedNode.id);
     }
 
@@ -222,7 +222,7 @@ class FlNodeEditorRunner {
         }
 
         for (final link in port.links) {
-          final connectedNode = _nodes[link.fromTo.fromPort]!;
+          final connectedNode = _nodes[link.fromTo.to]!;
           final connectedPort = connectedNode.ports[link.fromTo.toPort]!;
 
           connectedPort.data = data;

--- a/lib/src/core/models/entities.dart
+++ b/lib/src/core/models/entities.dart
@@ -54,11 +54,12 @@ final class Link {
   }
 
   Map<String, dynamic> toJson() {
+    // fixme: the JSON save format still uses the old names
     return {
       'id': id,
       'from': fromTo.from,
-      'to': fromTo.to,
-      'fromPort': fromTo.fromPort,
+      'to': fromTo.fromPort,
+      'fromPort': fromTo.to,
       'toPort': fromTo.toPort,
     };
   }
@@ -66,10 +67,11 @@ final class Link {
   factory Link.fromJson(Map<String, dynamic> json) {
     return Link(
       id: json['id'],
+      // fixme: see note on [toJson]
       fromTo: (
         from: json['from'],
-        to: json['to'],
-        fromPort: json['fromPort'],
+        fromPort: json['to'],
+        to: json['fromPort'],
         toPort: json['toPort'],
       ),
       state: LinkState(),

--- a/lib/src/widgets/node_editor_render_object.dart
+++ b/lib/src/widgets/node_editor_render_object.dart
@@ -527,8 +527,8 @@ class NodeEditorRenderBox extends RenderBox
 
       for (final link in _controller.linksById.values) {
         final outNode = _controller.nodes[link.fromTo.from]!;
-        final inNode = _controller.nodes[link.fromTo.fromPort]!;
-        final outPort = outNode.ports[link.fromTo.to]!;
+        final inNode = _controller.nodes[link.fromTo.to]!;
+        final outPort = outNode.ports[link.fromTo.fromPort]!;
         final inPort = inNode.ports[link.fromTo.toPort]!;
 
         final Rect pathBounds = Rect.fromPoints(


### PR DESCRIPTION
It seems like since PR #29, the names of `FromTo`'s fields have been swapped, resulting in the value of `to` and `fromPort` being also swapped. Previous code also used `fromPort` instead of `to` (and vice-versa), resulting in some pretty confusing code.

This PR simply "renames" the fields to make the code less confusing.

> [!WARNING]
> This bug also affects the JSON used by the saving/loading mechanism. This PR *does not* fix this, since it would make every old save incompatible without any earlier processing (and since the save file doesn't include any version code, it's impossible to adapt/guard against mismatched version uses out-of-the-box). If such a breaking change is fine, I'd be happy to also "fix" this in this PR!