### PR TITLE
Store port style in `PortInsstance` instead of calling `PortPrototype.styleBuilder`

### DIFF
--- a/lib/src/core/utils/single_listener_change_notifier.dart
+++ b/lib/src/core/utils/single_listener_change_notifier.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/foundation.dart';
+
+/// Tiny replacement for [ChangeNotifier] to optimize for the zero-or-one listener scenario
+mixin SingleListenerChangeNotifier implements Listenable {
+  VoidCallback? listener;
+
+  void notifyListeners() =>
+      listener?.call(); // just to be compatible with [ChangeNotifier]
+
+  @override
+  @visibleForOverriding
+  void addListener(VoidCallback listener) {
+    if (this.listener != null) {
+      throw StateError(
+        "Trying to add another listener, but this Listenable only supports one listener at a time",
+      );
+    }
+
+    this.listener = listener;
+  }
+
+  @override
+  @visibleForOverriding
+  void removeListener(VoidCallback listener) {
+    // just like most [Listenable]s, we ignore any listener that isn't ours (for usability purposes)
+    if (listener == this.listener) this.listener = null;
+  }
+
+  void dispose() => listener = null;
+}

--- a/lib/src/widgets/default_node_widget.dart
+++ b/lib/src/widgets/default_node_widget.dart
@@ -223,7 +223,7 @@ class _DefaultNodeWidgetState extends State<DefaultNodeWidget> {
     final absolutePortOffset = node.offset + port.offset;
 
     widget.controller.drawTempLink(
-      port.prototype.styleBuilder(port.state).linkStyleBuilder(LinkState()),
+      port.style.linkStyleBuilder(LinkState()),
       absolutePortOffset,
       worldPosition!,
     );

--- a/lib/src/widgets/node_editor_data_layer.dart
+++ b/lib/src/widgets/node_editor_data_layer.dart
@@ -283,7 +283,7 @@ class _NodeEditorDataLayerState extends State<NodeEditorDataLayer>
     final absolutePortOffset = node.offset + port.offset;
 
     widget.controller.drawTempLink(
-      port.prototype.styleBuilder(port.state).linkStyleBuilder(LinkState()),
+      port.style.linkStyleBuilder(LinkState()),
       absolutePortOffset,
       worldPosition!,
     );

--- a/lib/src/widgets/node_editor_render_object.dart
+++ b/lib/src/widgets/node_editor_render_object.dart
@@ -544,9 +544,7 @@ class NodeEditorRenderBox extends RenderBox
             id: link.id,
             outPortOffset: outNode.offset + outPort.offset,
             inPortOffset: inNode.offset + inPort.offset,
-            linkStyle: outPort.prototype
-                .styleBuilder(outPort.state)
-                .linkStyleBuilder(link.state),
+            linkStyle: outPort.style.linkStyleBuilder(link.state),
           ),
         );
       }
@@ -676,7 +674,7 @@ class NodeEditorRenderBox extends RenderBox
                 locator: (nodeId, port.prototype.idName),
                 isSelected: childParentData.state.isSelected,
                 offset: childParentData.offset + port.offset,
-                style: port.prototype.styleBuilder(port.state),
+                style: port.style,
               ),
             );
           }
@@ -696,7 +694,7 @@ class NodeEditorRenderBox extends RenderBox
                 locator: (nodeId, port.prototype.idName),
                 isSelected: childParentData.state.isSelected,
                 offset: childParentData.offset + port.offset,
-                style: port.prototype.styleBuilder(port.state),
+                style: port.style,
               ),
             );
           }


### PR DESCRIPTION
Instead of calling `PortPrototype.styleBuilder` with the port's state all the time, just give `PortInstance` the responsibility of knowing its style -- so that it can cache it and refresh it only when the state changes.