### PR TITLE
Fixed node layout

### DIFF
--- a/packages/fl_nodes_core/lib/src/widgets/node_editor_render_object.dart
+++ b/packages/fl_nodes_core/lib/src/widgets/node_editor_render_object.dart
@@ -440,7 +440,12 @@ class NodeEditorRenderBox extends RenderBox
       final childParentData = child.parentData! as _ParentData;
 
       child.layout(
-        BoxConstraints.loose(constraints.biggest),
+        const BoxConstraints(
+          minWidth: 0,
+          minHeight: 0,
+          maxWidth: double.infinity,
+          maxHeight: double.infinity,
+        ),
         parentUsesSize: true,
       );
 


### PR DESCRIPTION
Nodes with a fixed size couldn't be bigger than the viewport size and also nodes that had size constraints were scaled as the layout changed. The weird thing is that the scaling was also not consistent, sometimes they would scale when i resized my window sometimes they would not. This seems odd because the code seems to have previously simply constrained the nodes to not be any bigger than the entire viewport?

NOTE: I have not had a closer look at the rendering or internals of fl_nodes and have not verified if this causes any issues down the pipeline.