### PR TITLE
fix(fl_nodes_core): declare grid shader asset in pubspec.yaml

### DIFF
--- a/packages/fl_nodes_core/pubspec.yaml
+++ b/packages/fl_nodes_core/pubspec.yaml
@@ -43,3 +43,7 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ">=4.0.0 <7.0.0"
   test_coverage_badge: ^0.3.2
+
+flutter:
+  shaders:
+    - lib/shaders/grid.frag


### PR DESCRIPTION
## Summary

- `fl_nodes_core` ships `lib/shaders/grid.frag` but never declares it in `pubspec.yaml` under `flutter: shaders:`
- Any app depending on `fl_nodes` crashes at runtime with `Exception: Asset 'packages/fl_nodes_core/shaders/grid.frag' not found`
- This PR adds the missing declaration